### PR TITLE
オーダー番号の代入式と合計金額の式を修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -19,7 +19,7 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = (gets.to_i) - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -30,5 +30,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = (DRINKS[order1][:price]).to_i + (FOODS[order2][:price]).to_i
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
各メニューのオーダー番号と配列のインデックスが一致しないことから、頼んだものとは異なるメニューが表示されていたため、一致するように修正しました。
また、合計金額の式が文字列同士の足し算になっていたこと、ドリンクとフードで変数があべこべになっていたことから意図した金額にならなかったため、正しい合計金額が出るようにしました。